### PR TITLE
Fix argument validation for newer puppet

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -70,19 +70,19 @@
 #
 define getssl::domain (
   String            $base_dir                  = $getssl::base_dir,
-  Bool              $production                = $getssl::params::production,
+  Boolean           $production                = $getssl::params::production,
   String            $prod_ca                   = $getssl::params::prod_ca,
   String            $staging_ca                = $getssl::params::staging_ca,
   String            $domain                    = $name,
   Array[String]     $acl                       = $getssl::params::acl,
-  Bool              $use_single_acl            = $getssl::params::use_single_acl,
-  String            $domain_challenge_check_type = $getssl::params::domain_challenge_check_type,
+  Boolean           $use_single_acl            = $getssl::params::use_single_acl,
+  Optional[String]  $domain_challenge_check_type = $getssl::params::domain_challenge_check_type,
   Array[String]     $sub_domains               = $getssl::params::sub_domains,
   String            $domain_private_key_alg    = $getssl::params::domain_private_key_alg,
   Integer           $domain_account_key_length = $getssl::params::domain_account_key_length,
   Optional[String]  $domain_account_mail       = $getssl::params::domain_account_mail,
-  Bool              $domain_check_remote       = $getssl::params::domain_check_remote,
-  Integer           $domain_check_remote_wait  = $getssl::params::domain_check_remote_wait,
+  Boolean           $domain_check_remote       = $getssl::params::domain_check_remote,
+  Optional[Integer] $domain_check_remote_wait  = $getssl::params::domain_check_remote_wait,
   Optional[String]  $domain_reload_command     = $getssl::params::domain_reload_command,
   Integer           $domain_renew_allow        = $getssl::params::domain_renew_allow,
   String            $domain_server_type        = $getssl::params::domain_server_type,
@@ -92,7 +92,7 @@ define getssl::domain (
   Optional[String]  $domain_key_cert_location  = $getssl::params::domain_key_cert_location,
   Optional[String]  $domain_key_location       = $getssl::params::domain_key_location,
   Optional[String]  $domain_pem_location       = $getssl::params::domain_pem_location,
-  Bool              $suppress_getssl_run       = $getssl::params::suppress_getssl_run,
+  Boolean           $suppress_getssl_run       = $getssl::params::suppress_getssl_run,
 ) {
   # Use production api of letsencrypt only if $production is true
   if $production {

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -69,94 +69,36 @@
 #    }
 #
 define getssl::domain (
-  $base_dir                  = $getssl::base_dir,
-  $production                = $getssl::params::production,
-  $prod_ca                   = $getssl::params::prod_ca,
-  $staging_ca                = $getssl::params::staging_ca,
-  $domain                    = $name,
-  $acl                       = $getssl::params::acl,
-  $use_single_acl            = $getssl::params::use_single_acl,
-  $domain_challenge_check_type = $getssl::params::domain_challenge_check_type,
-  $sub_domains               = $getssl::params::sub_domains,
-  $domain_private_key_alg    = $getssl::params::domain_private_key_alg,
-  $domain_account_key_length = $getssl::params::domain_account_key_length,
-  $domain_account_mail       = $getssl::params::domain_account_mail,
-  $domain_check_remote       = $getssl::params::domain_check_remote,
-  $domain_check_remote_wait  = $getssl::params::domain_check_remote_wait,
-  $domain_reload_command     = $getssl::params::domain_reload_command,
-  $domain_renew_allow        = $getssl::params::domain_renew_allow,
-  $domain_server_type        = $getssl::params::domain_server_type,
-  $ca_cert_location          = $getssl::params::ca_cert_location,
-  $domain_cert_location      = $getssl::params::domain_cert_location,
-  $domain_chain_location     = $getssl::params::domain_chain_location,
-  $domain_key_cert_location  = $getssl::params::domain_key_cert_location,
-  $domain_key_location       = $getssl::params::domain_key_location,
-  $domain_pem_location       = $getssl::params::domain_pem_location,
-  $suppress_getssl_run       = $getssl::params::suppress_getssl_run,
+  String            $base_dir                  = $getssl::base_dir,
+  Bool              $production                = $getssl::params::production,
+  String            $prod_ca                   = $getssl::params::prod_ca,
+  String            $staging_ca                = $getssl::params::staging_ca,
+  String            $domain                    = $name,
+  Array[String]     $acl                       = $getssl::params::acl,
+  Bool              $use_single_acl            = $getssl::params::use_single_acl,
+  String            $domain_challenge_check_type = $getssl::params::domain_challenge_check_type,
+  Array[String]     $sub_domains               = $getssl::params::sub_domains,
+  String            $domain_private_key_alg    = $getssl::params::domain_private_key_alg,
+  Integer           $domain_account_key_length = $getssl::params::domain_account_key_length,
+  Optional[String]  $domain_account_mail       = $getssl::params::domain_account_mail,
+  Bool              $domain_check_remote       = $getssl::params::domain_check_remote,
+  Integer           $domain_check_remote_wait  = $getssl::params::domain_check_remote_wait,
+  Optional[String]  $domain_reload_command     = $getssl::params::domain_reload_command,
+  Integer           $domain_renew_allow        = $getssl::params::domain_renew_allow,
+  String            $domain_server_type        = $getssl::params::domain_server_type,
+  Optional[String]  $ca_cert_location          = $getssl::params::ca_cert_location,
+  Optional[String]  $domain_cert_location      = $getssl::params::domain_cert_location,
+  Optional[String]  $domain_chain_location     = $getssl::params::domain_chain_location,
+  Optional[String]  $domain_key_cert_location  = $getssl::params::domain_key_cert_location,
+  Optional[String]  $domain_key_location       = $getssl::params::domain_key_location,
+  Optional[String]  $domain_pem_location       = $getssl::params::domain_pem_location,
+  Bool              $suppress_getssl_run       = $getssl::params::suppress_getssl_run,
 ) {
-
-  validate_string($domain_private_key_alg, $domain_server_type)
-  validate_integer($domain_account_key_length)
-  validate_integer($domain_renew_allow)
-  validate_bool($domain_check_remote, $use_single_acl)
-
-  if $domain_challenge_check_type {
-    validate_string($domain_challenge_check_type)
-  }
-
-  if $ca_cert_location {
-    validate_string($ca_cert_location)
-  }
-
-  if $domain_cert_location {
-    validate_string($domain_cert_location)
-  }
-
-  if $domain_chain_location {
-    validate_string($domain_chain_location)
-  }
-
-  if $domain_key_cert_location {
-    validate_string($domain_key_cert_location)
-  }
-
-  if $domain_key_location {
-    validate_string($domain_key_location)
-  }
-
-  if $domain_pem_location {
-    validate_string($domain_pem_location)
-  }
-
-  if $domain_reload_command {
-    validate_string($domain_reload_command)
-  }
-
-  if $sub_domains {
-    validate_array($sub_domains)
-  }
-
-  if $acl and size($acl) > 0 {
-    validate_array($acl)
-  } else {
-    fail('You have to set acl in your manifest!')
-  }
-
   # Use production api of letsencrypt only if $production is true
   if $production {
     $ca = $prod_ca
   } else {
     $ca = $staging_ca
-  }
-
-  if !$domain {
-    fail('$domain must be set')
-  } else {
-    validate_string($domain)
-  }
-
-  if $domain_account_mail {
-    validate_string($domain_account_mail)
   }
 
   $parent_dir = {
@@ -173,7 +115,7 @@ define getssl::domain (
     $config_notifiers = []
   } else {
     # Default behaviour
-    $config_notifiers = [ Exec["${base_dir}/getssl -U -w ${base_dir}/conf -q ${domain}"] ]
+    $config_notifiers = [Exec["${base_dir}/getssl -U -w ${base_dir}/conf -q ${domain}"]]
   }
 
   file { "${base_dir}/conf/${domain}/getssl.cfg":
@@ -182,27 +124,27 @@ define getssl::domain (
     group   => root,
     mode    => '0644',
     content => epp('getssl/domain_getssl.cfg.epp', {
-      'acl'                       => $acl,
-      'base_dir'                  => $base_dir,
-      'ca'                        => $ca,
-      'ca_cert_location'          => $ca_cert_location,
-      'domain'                    => $domain,
-      'domain_account_key_length' => $domain_account_key_length,
-      'domain_account_mail'       => $domain_account_mail,
-      'domain_cert_location'      => $domain_cert_location,
-      'domain_chain_location'     => $domain_chain_location,
-      'domain_check_remote'       => $domain_check_remote,
-      'domain_check_remote_wait'  => $domain_check_remote_wait,
-      'domain_key_cert_location'  => $domain_key_cert_location,
-      'domain_key_location'       => $domain_key_location,
-      'domain_pem_location'       => $domain_pem_location,
-      'domain_private_key_alg'    => $domain_private_key_alg,
-      'domain_reload_command'     => $domain_reload_command,
-      'domain_renew_allow'        => $domain_renew_allow,
-      'domain_server_type'        => $domain_server_type,
-      'sub_domains'               => $sub_domains,
-      'use_single_acl'            => $use_single_acl,
-      'domain_challenge_check_type' => $domain_challenge_check_type
+        'acl'                         => $acl,
+        'base_dir'                    => $base_dir,
+        'ca'                          => $ca,
+        'ca_cert_location'            => $ca_cert_location,
+        'domain'                      => $domain,
+        'domain_account_key_length'   => $domain_account_key_length,
+        'domain_account_mail'         => $domain_account_mail,
+        'domain_cert_location'        => $domain_cert_location,
+        'domain_chain_location'       => $domain_chain_location,
+        'domain_check_remote'         => $domain_check_remote,
+        'domain_check_remote_wait'    => $domain_check_remote_wait,
+        'domain_key_cert_location'    => $domain_key_cert_location,
+        'domain_key_location'         => $domain_key_location,
+        'domain_pem_location'         => $domain_pem_location,
+        'domain_private_key_alg'      => $domain_private_key_alg,
+        'domain_reload_command'       => $domain_reload_command,
+        'domain_renew_allow'          => $domain_renew_allow,
+        'domain_server_type'          => $domain_server_type,
+        'sub_domains'                 => $sub_domains,
+        'use_single_acl'              => $use_single_acl,
+        'domain_challenge_check_type' => $domain_challenge_check_type
     }),
     notify  => $config_notifiers,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@
 #     Global Email Address for Letsencrypt registration
 #   [*account_key_length*]
 #     Account key length. Default 4096
-#   [*account_key_alg*]
+#   [*private_key_alg*]
 #     Account key algorythm. Default rsa
 #   [*reload_command*]
 #     Specifies reload for services. E.g systemctl restart apach2. Default undef
@@ -59,42 +59,29 @@
 # -------
 #
 # Author Name <github@thielking-vonessen.de>
-
 class getssl (
-  $base_dir           = $getssl::params::base_dir,
-  $production         = $getssl::params::production,
-  $prod_ca            = $getssl::params::prod_ca,
-  $staging_ca         = $getssl::params::staging_ca,
-  $manage_packages    = $getssl::params::manage_packages,
-  $packages           = $getssl::params::packages,
-  $manage_cron        = $getssl::params::manage_cron,
-  $account_mail       = $getssl::params::account_mail,
-  $account_key_length = $getssl::params::account_key_length,
-  $private_key_alg    = $getssl::params::private_key_alg,
-  $reload_command     = $getssl::params::reload_command,
-  $reuse_private_key  = $getssl::params::reuse_private_key,
-  $renew_allow        = $getssl::params::renew_allow,
-  $server_type        = $getssl::params::server_type,
-  $check_remote       = $getssl::params::check_remote,
-  $ssl_conf           = $getssl::params::ssl_conf,
+  String            $base_dir            = $getssl::params::base_dir,
+  Bool              $production         = $getssl::params::production,
+  String            $prod_ca            = $getssl::params::prod_ca,
+  String            $staging_ca         = $getssl::params::staging_ca,
+  Bool              $manage_packages    = $getssl::params::manage_packages,
+  Array[String]     $packages           = $getssl::params::packages,
+  Bool              $manage_cron        = $getssl::params::manage_cron,
+  Optional[String]  $account_mail       = $getssl::params::account_mail,
+  Integer           $account_key_length = $getssl::params::account_key_length,
+  String            $private_key_alg    = $getssl::params::private_key_alg,
+  String            $reload_command     = $getssl::params::reload_command,
+  Bool              $reuse_private_key  = $getssl::params::reuse_private_key,
+  Integer           $renew_allow        = $getssl::params::renew_allow,
+  String            $server_type        = $getssl::params::server_type,
+  Bool              $check_remote       = $getssl::params::check_remote,
+  String            $ssl_conf           = $getssl::params::ssl_conf,
 ) inherits getssl::params {
-
-  # Check all variables
-  validate_string($base_dir, $ssl_conf, $server_type, $reload_command)
-  validate_bool($manage_packages, $production, $reuse_private_key, $check_remote)
-  validate_array($packages)
-  validate_integer($account_key_length)
-  validate_integer($renew_allow)
-
   # Use production api of letsencrypt if $production is true
   if $production {
     $ca = $prod_ca
   } else {
     $ca = $staging_ca
-  }
-
-  if $account_mail {
-    validate_string($account_mail)
   }
 
   # Install packages if $manage_packages is true
@@ -132,17 +119,17 @@ class getssl (
     group   => root,
     mode    => '0644',
     content => epp('getssl/global_getssl.cfg.epp', {
-      'ca'                 => $ca,
-      'account_mail'       => $account_mail,
-      'account_key_length' => $account_key_length,
-      'base_dir'           => $base_dir,
-      'private_key_alg'    => $private_key_alg,
-      'reuse_private_key'  => $reuse_private_key,
-      'reload_command'     => $reload_command,
-      'renew_allow'        => $renew_allow,
-      'server_type'        => $server_type,
-      'check_remote'       => $check_remote,
-      'ssl_conf'           => $ssl_conf,
+        'ca'                 => $ca,
+        'account_mail'       => $account_mail,
+        'account_key_length' => $account_key_length,
+        'base_dir'           => $base_dir,
+        'private_key_alg'    => $private_key_alg,
+        'reuse_private_key'  => $reuse_private_key,
+        'reload_command'     => $reload_command,
+        'renew_allow'        => $renew_allow,
+        'server_type'        => $server_type,
+        'check_remote'       => $check_remote,
+        'ssl_conf'           => $ssl_conf,
     }),
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,20 +61,20 @@
 # Author Name <github@thielking-vonessen.de>
 class getssl (
   String            $base_dir            = $getssl::params::base_dir,
-  Bool              $production         = $getssl::params::production,
+  Boolean           $production         = $getssl::params::production,
   String            $prod_ca            = $getssl::params::prod_ca,
   String            $staging_ca         = $getssl::params::staging_ca,
-  Bool              $manage_packages    = $getssl::params::manage_packages,
+  Boolean           $manage_packages    = $getssl::params::manage_packages,
   Array[String]     $packages           = $getssl::params::packages,
-  Bool              $manage_cron        = $getssl::params::manage_cron,
+  Boolean           $manage_cron        = $getssl::params::manage_cron,
   Optional[String]  $account_mail       = $getssl::params::account_mail,
   Integer           $account_key_length = $getssl::params::account_key_length,
   String            $private_key_alg    = $getssl::params::private_key_alg,
   String            $reload_command     = $getssl::params::reload_command,
-  Bool              $reuse_private_key  = $getssl::params::reuse_private_key,
+  Boolean           $reuse_private_key  = $getssl::params::reuse_private_key,
   Integer           $renew_allow        = $getssl::params::renew_allow,
   String            $server_type        = $getssl::params::server_type,
-  Bool              $check_remote       = $getssl::params::check_remote,
+  Boolean           $check_remote       = $getssl::params::check_remote,
   String            $ssl_conf           = $getssl::params::ssl_conf,
 ) inherits getssl::params {
   # Use production api of letsencrypt if $production is true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@
 #
 #   This class sets all the sufficient default settings
 #
-class getssl::params{
+class getssl::params {
   # Main parts
   $base_dir                  = '/opt/getssl'
   $production                = false


### PR DESCRIPTION
This switches from `validate_`, which is now obsolete, to using declared types